### PR TITLE
Configuration improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,10 @@ MAINTAINER Arkivum Limited
 # Copy the files_mv app to NextCloud
 COPY build/files_mv /nextcloud/apps/files_mv
 
+# Redirect NextCloud logs to stdout
+RUN rm -f /var/log/nextcloud.log && \
+	ln -s /dev/stdout /var/log/nextcloud.log
+
 # Replace the default setup.sh with our own
 COPY rootfs/usr/local/bin/arkivum-setup.sh /usr/local/bin/arkivum-setup.sh
 RUN mv /usr/local/bin/setup.sh /usr/local/bin/base-setup.sh && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,11 @@ FROM wonderfall/nextcloud
 
 MAINTAINER Arkivum Limited
 
+# Use EnvPlate for templating
+RUN curl -sLo /usr/local/bin/ep \
+    https://github.com/kreuzwerker/envplate/releases/download/v0.0.8/ep-linux \
+    && chmod +x /usr/local/bin/ep
+
 # Copy the files_mv app to NextCloud
 COPY build/files_mv /nextcloud/apps/files_mv
 
@@ -13,3 +18,6 @@ RUN rm -f /var/log/nextcloud.log && \
 COPY rootfs/usr/local/bin/arkivum-setup.sh /usr/local/bin/arkivum-setup.sh
 RUN mv /usr/local/bin/setup.sh /usr/local/bin/base-setup.sh && \
     ln -s /usr/local/bin/arkivum-setup.sh /usr/local/bin/setup.sh
+
+# Copy our config template
+COPY rootfs/config/config.php.template /config/config.php.template

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,52 @@
+---
+version: '2'
+
+volumes:
+    # Named volume for database persistence
+    mysql_data:
+
+    # Named volumes for NextCloud persistence
+    nextcloud_apps:
+    nextcloud_config:
+    nextcloud_data:
+    nextcloud_sessions:
+    nextcloud_themes:
+
+services:
+
+    mysql:
+        image: "percona:5.6"
+        user: "mysql"
+        environment:
+            MYSQL_ROOT_PASSWORD: "12345"
+        volumes:
+            - "mysql_data:/var/lib/mysql"
+        expose:
+            - "3306"
+
+    nextcloud:
+        image: "arkivum/nextcloud"
+        build: .
+        environment:
+            ADMIN_USER: "admin"
+            ADMIN_PASSWORD: "admin"
+            DB_HOST: "mysql"
+            DB_USER: "root"
+            DB_PASSWORD: "12345"
+            DB_PORT: "3306"
+            DB_TYPE: "mysql"
+            GID: "1000"
+            UID: "1000"
+        volumes:
+            # Nextcloud persistence
+            - "nextcloud_apps:/apps2"
+            - "nextcloud_config:/config"
+            - "nextcloud_data:/data"
+            - "nextcloud_themes:/nextcloud/themes"
+            - "nextcloud_sessions:/php/session"
+        ports:
+            - "38888:8888"
+        depends_on:
+            - "mysql"
+        links:
+            - "mysql"

--- a/rootfs/config/config.php.template
+++ b/rootfs/config/config.php.template
@@ -1,0 +1,81 @@
+<?php
+# NextCloud config settings
+# See https://docs.nextcloud.com/server/12/admin_manual/configuration_server/config_sample_php_parameters.html
+$CONFIG = array (
+
+  #
+  # Customizable settings - can be overridden with environment variables
+  #
+
+  # Email
+  'mail_domain' => getenv('NC_MAIL_DOMAIN') ?: 'localhost',
+  'mail_from_address' => getenv('NC_MAIL_FROM_ADDRESS') ?: 'nextcloud-noreply',
+  'mail_smtpdebug' => getenv('NC_MAIL_DEBUG_ENABLED') ?: false,
+  'mail_smtphost' => getenv('NC_MAIL_HOST') ?: 'localhost',
+  'mail_smtpname' => getenv('NC_MAIL_USER') ?: '',
+  'mail_smtppassword' => getenv('NC_MAIL_PASSWORD') ?: '',
+  'mail_smtpport' => getenv('NC_MAIL_PORT') ?: 25,
+  'mail_smtpsecure' => getenv('NC_MAIL_SECURE') ?: '',
+  'mail_smtptimeout' => getenv('NC_MAIL_TIMEOUT') ?: 10,
+
+  # Logging
+  'loglevel' => getenv('NC_LOG_LEVEL') ?: 1,
+
+  #
+  # Installed settings - you shouldn't need to change these, ever
+  #
+
+  # System
+  'instanceid' => '${NC_INSTANCE_ID}',
+  'version' => '12.0.3.3',
+  'installed' => true,
+
+  # Database
+  'dbtype' => 'mysql',
+  'dbname' => 'nextcloud',
+  'dbhost' => '${NC_DB_HOST}',
+  'dbport' => '${NC_DB_PORT}',
+  'dbtableprefix' => 'oc_',
+  'dbuser' => '${NC_DB_USER}',
+  'dbpassword' => '${NC_DB_PASSWORD_CRYPTED}',
+
+  # Caching
+  'memcache.local' => '\\OC\\Memcache\\APCu',
+
+  # Paths
+  'datadirectory' => '/data',
+  'apps_paths' => array (
+    0 => array (
+      'path' => '/nextcloud/apps',
+      'url' => '/apps',
+      'writable' => false,
+    ),
+    1 => array (
+      'path' => '/apps2',
+      'url' => '/apps2',
+      'writable' => true,
+    ),
+  ),
+  'skeletondirectory' => '',
+
+  # Security
+  'passwordsalt' => '${NC_PASSWORD_SALT}',
+  'secret' => '${NC_SECRET}',
+  'trusted_domains' => array (
+    0 => 'localhost',
+    1 => '*',
+  ),
+
+  # Logging
+  'logtimezone' => 'Etc/UTC',
+  'logdateformat' => 'Y-m-d H:i:s',
+
+  # Email
+  'mail_smtpauthtype' => 'LOGIN',
+  'mail_smtpmode' => 'smtp',
+
+  # Miscellaneous
+  'filesystem_check_changes' => 1,
+  'overwrite.cli.url' => 'http://localhost',
+);
+?>

--- a/rootfs/usr/local/bin/arkivum-setup.sh
+++ b/rootfs/usr/local/bin/arkivum-setup.sh
@@ -9,20 +9,23 @@
 #
 EXTERNAL_STORAGES="${EXTERNAL_STORAGES}"
 
+# STAGE 1: PRE-INSTALL #########################################################
+
 # Fill in minimial config params if they're missing
 export ADMIN_USER="${ADMIN_USER:-'admin'}"
 export ADMIN_PASSWORD="${ADMIN_PASSWORD:-'admin'}"
 
-# Include DB_PORT in base setup script
+# Edit base setup script to use DB_PORT for dbport value
 cp '/usr/local/bin/base-setup.sh' '/usr/local/bin/base-setup.sh.orig' && \
 < '/usr/local/bin/base-setup.sh.orig' \
     tr '\n' '\r' | \
-    sed "s#EOF\\rif \\[#  'dbport'        => '\\${DB_PORT}',\\rEOF\\rif \\[#" | \
+    sed "s|EOF\\rif \\[|  'dbport'        => '\\${DB_PORT}',\\rEOF\\rif \\[|" | \
     tr '\r' '\n' > '/usr/local/bin/base-setup.sh'
 
 # Base install runs auto-install in background. but we want it in foreground so
 # we know when it's finished.
-sed -i 's#php index.php &>/dev/null#php index.php#' /usr/local/bin/base-setup.sh
+sed -i 's#php index.php &>/dev/null#php index.php#' \
+    '/usr/local/bin/base-setup.sh'
 
 # Wait for database server to be ready, if necessary
 if [ "${DB_TYPE}" != "sqlite3" ] ; then
@@ -32,11 +35,52 @@ if [ "${DB_TYPE}" != "sqlite3" ] ; then
     done
 fi
 
-# Remove the default demo files provided with Nextcloud
-rm -Rf /nextcloud/core/skeleton/*
+# STAGE 2: INSTALL #############################################################
 
 # Do the base setup
 /usr/local/bin/base-setup.sh
+
+# STAGE 3: POST-INSTALL CONFIG #################################################
+
+# Create a backup of the default config
+[ -f /config/config.php.default ] || \
+    cp -p /config/config.php /config/config.php.default
+
+#
+# Replace the default config with our own templated config, keeping any
+# auto-generated values like instance id and password salt etc.
+#
+
+# Capture existing values from the existing config
+# shellcheck disable=SC2016
+instance_id="$(php -r \
+    'include "/config/config.php"; echo $CONFIG["instanceid"];')"
+# shellcheck disable=SC2016
+db_user="$(php -r \
+    'include "/config/config.php"; echo $CONFIG["dbuser"];')"
+# shellcheck disable=SC2016
+db_password_crypted="$(php -r \
+    'include "/config/config.php"; echo $CONFIG["dbpassword"];')"
+# shellcheck disable=SC2016
+password_salt="$(php -r \
+    'include "/config/config.php"; echo $CONFIG["passwordsalt"];')"
+# shellcheck disable=SC2016
+secret="$(php -r \
+    'include "/config/config.php"; echo $CONFIG["secret"];')"
+
+# Use EnvPlate to process our template and replace the existing config
+cp -p /config/config.php.template /config/config.php.new
+NC_DB_HOST="${DB_HOST}" \
+NC_DB_PORT="${DB_PORT}" \
+NC_DB_USER="${db_user}" \
+NC_DB_PASSWORD_CRYPTED="${db_password_crypted}" \
+NC_INSTANCE_ID="${instance_id}" \
+NC_PASSWORD_SALT="${password_salt}" \
+NC_SECRET="${secret}" \
+    ep /config/config.php.new && \
+    mv /config/config.php.new /config/config.php
+
+# STAGE 4: POST-CONFIG BOOTSTRAP ###############################################
 
 # Enable 'External Storage' plugin
 occ "app:enable files_external"
@@ -45,7 +89,7 @@ occ "app:enable files_external"
 occ "app:enable files_mv"
 
 # Create requested external storage locations
-for storage in $EXTERNAL_STORAGES ; do
+for storage in ${EXTERNAL_STORAGES} ; do
     storage_name=$(echo "${storage}" | cut -d: -f1)
     storage_dir=$(echo "${storage}" | cut -d: -f2)
     occ files_external:create \

--- a/rootfs/usr/local/bin/arkivum-setup.sh
+++ b/rootfs/usr/local/bin/arkivum-setup.sh
@@ -58,4 +58,4 @@ done
 occ config:system:set trusted_domains 1 --value="*"
 
 # Rescan file system
-occ files:scan --all
+occ files:scan --all &


### PR DESCRIPTION
NextCloud uses a single `config.php` for its configuration. This is created by the installer and then a sysadmin is expected to tweak and change it to meet their configuration requirements.

For our Docker image this isn't appropriate: we don't want to have sysadmins needing to tweak the deployed configuration.

This pull request changes the container configuration to use a template configuration file, which is then completed using environment variables, as well as keeping generated values from the installer-created configuration. This is done using the [EnvPlate](https://github.com/kreuzwerker/envplate) utility, which is what interpolates the variable values into the template file.

It also makes a few other changes:
1. The initial `occ:scan --all` is now run as a background task, so that the setup can complete and the NextCloud web interface started before the scan has finished.
1. The NextCloud log file, `/var/log/nextcloud.log`, is now a symlink to `/dev/stdout`, so that output is exposed to the `docker logs` command.
1. Add a very simple `docker-compose.yml` file for testing and development purposes.

As part of the templating, a number of new environment variables have been added, mainly to do with mail settings. I've tried to make the configuration as comprehensive as possible but there is probably still scope for improvement as part of future work.