### PR TITLE
add travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,12 @@
+---
+
+language: bash
+
+script:
+  # Validate all shell scripts
+  - find . \( -name \*.sh -or -name \*.bash \) -exec shellcheck -x -f gcc {} +
+  # TODO Add additional validation/build steps here
+
+notifications:
+  email: false
+

--- a/rootfs/usr/local/bin/arkivum-setup.sh
+++ b/rootfs/usr/local/bin/arkivum-setup.sh
@@ -10,14 +10,14 @@
 EXTERNAL_STORAGES="${EXTERNAL_STORAGES}"
 
 # Fill in minimial config params if they're missing
-export ADMIN_USER=${ADMIN_USER:-'admin'}
-export ADMIN_PASSWORD=${ADMIN_PASSWORD:-'admin'}
+export ADMIN_USER="${ADMIN_USER:-'admin'}"
+export ADMIN_PASSWORD="${ADMIN_PASSWORD:-'admin'}"
 
 # Include DB_PORT in base setup script
 cp '/usr/local/bin/base-setup.sh' '/usr/local/bin/base-setup.sh.orig' && \
-cat '/usr/local/bin/base-setup.sh.orig' | \
+< '/usr/local/bin/base-setup.sh.orig' \
     tr '\n' '\r' | \
-    sed "s#EOF\rif \[#  'dbport'        => '\${DB_PORT}',\rEOF\rif \[#" | \
+    sed "s#EOF\\rif \\[#  'dbport'        => '\\${DB_PORT}',\\rEOF\\rif \\[#" | \
     tr '\r' '\n' > '/usr/local/bin/base-setup.sh'
 
 # Base install runs auto-install in background. but we want it in foreground so
@@ -26,7 +26,7 @@ sed -i 's#php index.php &>/dev/null#php index.php#' /usr/local/bin/base-setup.sh
 
 # Wait for database server to be ready, if necessary
 if [ "${DB_TYPE}" != "sqlite3" ] ; then
-    while [ $(nc -z ${DB_HOST} ${DB_PORT} ; echo $?) -ne 0 ] ; do
+    while [ "$(nc -z "${DB_HOST}" "${DB_PORT}" ; echo "$?")" -ne 0 ] ; do
         2> echo "Waiting for ${DB_TYPE} database to be ready..."
         sleep 2
     done
@@ -46,11 +46,11 @@ occ "app:enable files_mv"
 
 # Create requested external storage locations
 for storage in $EXTERNAL_STORAGES ; do
-    storage_name=$(echo "$storage" | cut -d: -f1)
-    storage_dir=$(echo "$storage" | cut -d: -f2)
+    storage_name=$(echo "${storage}" | cut -d: -f1)
+    storage_dir=$(echo "${storage}" | cut -d: -f2)
     occ files_external:create \
-        --config datadir=$storage_dir \
-        $storage_name \
+        --config datadir="${storage_dir}" \
+        "${storage_name}" \
         'local' null::null
 done
 

--- a/src/files_mv/build.sh
+++ b/src/files_mv/build.sh
@@ -1,6 +1,6 @@
-#!/bin/sh
+#!/bin/bash
 
-BUILD_OWNER=${BUILD_OWNER:-$UID:$GID}
+BUILD_OWNER="${BUILD_OWNER:-$UID:$GID}"
 
 # Create the build dir, in case it doesn't already exist
 mkdir -p /build/
@@ -17,4 +17,4 @@ git clone https://github.com/eotryx/oc_files_mv.git /tmp/files_mv/ && \
 tar xzf /tmp/files_mv/build/artifacts/appstore/files_mv.tar.gz -C  /build/
 
 # Chown build output to the right owner
-chown -R $BUILD_OWNER /build/*
+chown -R "${BUILD_OWNER}" /build/*


### PR DESCRIPTION
Travis CI is now configured to run ShellCheck for all shell scripts.

These checks can be run manually using the `make validate` target.

Also fixed linting errors that were picked up by ShellCheck.