### PR TITLE
Use environment variables to configure redis connection and database name

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ In addition, the following are also supported:
 
 | Variable | Description | Default Value |
 |---|---|---|
-| `DB_PORT` | Specifies the port to use to connect to the external database server. | `""` |
+| `DB_PORT` | Specifies the port to use to connect to the MySQL database server. | `3306` |
 | `EXTERNAL_STORAGES` | Specifies the external storage location(s) that should be added as part of the set up. See [External Storage](#external-storage) below. | `""` |
 | `NC_LOG_LEVEL` | The level to log messages for. Valid values are one of the following numbers: <ul><li>0: DEBUG - all activity, the most detailed logging</li><li>1: INFO - activity such as user logins and file activities, plus warnings, errors and fatal errors</li><li>2: WARN - operations succeed, but with warnings of potential problems, plus errors and fatal errors</li><li>3: ERROR - an operation fails, but other services and operations continue, plus fatal errors</li><li>4: FATAL - the server stops</li></ul> | `1` |
 | `NC_MAIL_DOMAIN` | The domain to use when sending mails from NextCloud. | `localhost` |

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ In addition, the following are also supported:
 | `NC_MAIL_SECURE` | What security mechanism to use when sending mail. Valid values are `ssl`, `tls` or none. | none |
 | `NC_MAIL_TIMEOUT` | The timeout to use when sending mail, in seconds. | `10` |
 | `NC_MAIL_USER` | The SMTP username to use when sending mail | none |
+| `REDIS_HOST` | The hostname of the Redis server to use for caching. |
+| `REDIS_PORT` | The port of the Redis server to use for caching. |
 
 External Storage
 -----------------
@@ -75,7 +77,7 @@ Do this for each external location and you can then reference them by name inste
 		--volume my_docs:/mnt/docs \
 		--volume my_music:/mnt/music \
 		arkivum/nextcloud
-		
+
 Mail Settings
 --------------
 
@@ -94,6 +96,18 @@ The `NC_MAIL_*` environment variables are used to configure the SMTP settings to
 		arkivum/nextcloud
 
 Note that unauthenticated mail sending is not supported, so you must always specify the `NC_MAIL_USER` and `NC_MAIL_PASSWORD` for NextCloud to be able to send any mail messages.
+
+Redis Settings
+---------------
+
+NextCloud is configured to use Redis for caching to improve perfomance. To configure the hostname and port to use for the Redis server, use the `REDIS_HOST` and `REDIS_PORT` environment variables:
+
+	docker-run \
+		--env REDIS_HOST=redis-master \
+		--env REDIS_PORT=6380 \
+		arkivum/nextcloud
+
+Although NextCloud supports it, it is not currently possible to specify more than one host for NextCloud to connect to. This is on the assumption that any clustering will be done behind a single DNS hostname, so is better handled at the infrastructure layer than in the application.
 
 Usage with Docker Compose
 --------------------------

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,6 +33,7 @@ services:
             ADMIN_USER: "admin"
             ADMIN_PASSWORD: "admin"
             DB_HOST: "mysql"
+            DB_NAME: "nextcloud"
             DB_USER: "root"
             DB_PASSWORD: "12345"
             DB_PORT: "3306"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -39,6 +39,8 @@ services:
             DB_PORT: "3306"
             DB_TYPE: "mysql"
             GID: "1000"
+            REDIS_HOST: "redis"
+            REDIS_PORT: "6379"
             UID: "1000"
         volumes:
             - "nextcloud_data:/var/lib/nextcloud"

--- a/rootfs/nextcloud/config/config.php.template
+++ b/rootfs/nextcloud/config/config.php.template
@@ -12,6 +12,12 @@ $CONFIG = array (
   'dbhost' => getenv('DB_HOST') ?: 'mysql',
   'dbport' => getenv('DB_PORT') ?: 3306,
 
+  # Caching
+  'redis' => array(
+    'host' => getenv('REDIS_HOST') ?: 'redis',
+    'port' => getenv('REDIS_PORT') ?: 6379,
+  ),
+
   # Email
   'mail_domain' => getenv('NC_MAIL_DOMAIN') ?: 'localhost',
   'mail_from_address' => getenv('NC_MAIL_FROM_ADDRESS') ?: 'nextcloud-noreply',
@@ -45,10 +51,6 @@ $CONFIG = array (
   'memcache.local' => '\OC\Memcache\APCu',
   'memcache.distributed' => '\OC\Memcache\Redis',
   'memcache.locking' => '\OC\Memcache\Redis',
-  'redis' => array(
-    'host' => 'redis',
-    'port' => 6379,
-  ),
 
   # Paths
   'datadirectory' => '/var/lib/nextcloud/data',

--- a/rootfs/nextcloud/config/config.php.template
+++ b/rootfs/nextcloud/config/config.php.template
@@ -7,6 +7,11 @@ $CONFIG = array (
   # Customizable settings - can be overridden with environment variables
   #
 
+  # Database
+  'dbname' => getenv('DB_NAME') ?: 'nextcloud',
+  'dbhost' => getenv('DB_HOST') ?: 'mysql',
+  'dbport' => getenv('DB_PORT') ?: 3306,
+
   # Email
   'mail_domain' => getenv('NC_MAIL_DOMAIN') ?: 'localhost',
   'mail_from_address' => getenv('NC_MAIL_FROM_ADDRESS') ?: 'nextcloud-noreply',
@@ -32,9 +37,6 @@ $CONFIG = array (
 
   # Database
   'dbtype' => 'mysql',
-  'dbname' => 'nextcloud',
-  'dbhost' => '${NC_DB_HOST}',
-  'dbport' => '${NC_DB_PORT}',
   'dbtableprefix' => 'oc_',
   'dbuser' => '${NC_DB_USER}',
   'dbpassword' => '${NC_DB_PASSWORD_CRYPTED}',

--- a/rootfs/usr/local/bin/arkivum-config.sh
+++ b/rootfs/usr/local/bin/arkivum-config.sh
@@ -1,0 +1,35 @@
+#!/bin/sh
+
+#
+# Replace the current config with our own templated config, keeping any
+# auto-generated values like instance id and password salt etc.
+#
+
+# Capture existing values from the existing config
+# shellcheck disable=SC2016
+instance_id="$(php -r \
+    'include "/var/lib/nextcloud/config/config.php"; echo $CONFIG["instanceid"];')"
+# shellcheck disable=SC2016
+db_user="$(php -r \
+    'include "/var/lib/nextcloud/config/config.php"; echo $CONFIG["dbuser"];')"
+# shellcheck disable=SC2016
+db_password_crypted="$(php -r \
+    'include "/var/lib/nextcloud/config/config.php"; echo $CONFIG["dbpassword"];')"
+# shellcheck disable=SC2016
+password_salt="$(php -r \
+    'include "/var/lib/nextcloud/config/config.php"; echo $CONFIG["passwordsalt"];')"
+# shellcheck disable=SC2016
+secret="$(php -r \
+    'include "/var/lib/nextcloud/config/config.php"; echo $CONFIG["secret"];')"
+
+# Use EnvPlate to process our template and replace the existing config
+cp -p /nextcloud/config/config.php.template \
+    /var/lib/nextcloud/config/config.php.new
+NC_DB_USER="${db_user}" \
+NC_DB_PASSWORD_CRYPTED="${db_password_crypted}" \
+NC_INSTANCE_ID="${instance_id}" \
+NC_PASSWORD_SALT="${password_salt}" \
+NC_SECRET="${secret}" \
+    ep /var/lib/nextcloud/config/config.php.new && \
+    mv /var/lib/nextcloud/config/config.php.new /var/lib/nextcloud/config/config.php && \
+    echo "Updated NextCloud configuration from template."

--- a/rootfs/usr/local/bin/arkivum-setup.sh
+++ b/rootfs/usr/local/bin/arkivum-setup.sh
@@ -79,8 +79,6 @@ secret="$(php -r \
 # Use EnvPlate to process our template and replace the existing config
 cp -p /nextcloud/config/config.php.template \
     /var/lib/nextcloud/config/config.php.new
-NC_DB_HOST="${DB_HOST}" \
-NC_DB_PORT="${DB_PORT}" \
 NC_DB_USER="${db_user}" \
 NC_DB_PASSWORD_CRYPTED="${db_password_crypted}" \
 NC_INSTANCE_ID="${instance_id}" \

--- a/rootfs/usr/local/bin/arkivum-setup.sh
+++ b/rootfs/usr/local/bin/arkivum-setup.sh
@@ -58,34 +58,7 @@ cp -pr /apps2 /var/lib/nextcloud/ && \
 # Replace the default config with our own templated config, keeping any
 # auto-generated values like instance id and password salt etc.
 #
-
-# Capture existing values from the existing config
-# shellcheck disable=SC2016
-instance_id="$(php -r \
-    'include "/var/lib/nextcloud/config/config.php"; echo $CONFIG["instanceid"];')"
-# shellcheck disable=SC2016
-db_user="$(php -r \
-    'include "/var/lib/nextcloud/config/config.php"; echo $CONFIG["dbuser"];')"
-# shellcheck disable=SC2016
-db_password_crypted="$(php -r \
-    'include "/var/lib/nextcloud/config/config.php"; echo $CONFIG["dbpassword"];')"
-# shellcheck disable=SC2016
-password_salt="$(php -r \
-    'include "/var/lib/nextcloud/config/config.php"; echo $CONFIG["passwordsalt"];')"
-# shellcheck disable=SC2016
-secret="$(php -r \
-    'include "/var/lib/nextcloud/config/config.php"; echo $CONFIG["secret"];')"
-
-# Use EnvPlate to process our template and replace the existing config
-cp -p /nextcloud/config/config.php.template \
-    /var/lib/nextcloud/config/config.php.new
-NC_DB_USER="${db_user}" \
-NC_DB_PASSWORD_CRYPTED="${db_password_crypted}" \
-NC_INSTANCE_ID="${instance_id}" \
-NC_PASSWORD_SALT="${password_salt}" \
-NC_SECRET="${secret}" \
-    ep /var/lib/nextcloud/config/config.php.new && \
-    mv /var/lib/nextcloud/config/config.php.new /var/lib/nextcloud/config/config.php
+/usr/local/bin/arkivum-config.sh
 
 # STAGE 4: POST-CONFIG BOOTSTRAP ###############################################
 


### PR DESCRIPTION
This pull request addresses [RDSSARK-386](https://jiscdev.atlassian.net/browse/RDSSARK-386) and [RDSSARK-387](https://jiscdev.atlassian.net/browse/RDSSARK-387) and makes the following changes:

* Allow the `dbname` config value to be set from the `DB_NAME` environment variable
* Allow the `redis` config value to be set from the `REDIS_HOST` and `REDIS_PORT` environment variables
* Use the MD5 checksum of the config template to determine if the config file needs updating, rather than whether or not it exists

The last of these is required because we are making changes to an existing working system, rather than providing input for the setup during the installation process. Previously it was assumed that changes to the config file itself would only be required during install, so this adds support for changes during upgrades too.
  