### PR TITLE
ensure environment variables get passed to NextCloud processes

### DIFF
--- a/rootfs/usr/local/bin/run.sh
+++ b/rootfs/usr/local/bin/run.sh
@@ -19,6 +19,10 @@ sed -i -e "s/<APC_SHM_SIZE>/$APC_SHM_SIZE/g" /php/conf.d/apcu.ini \
            /nginx/conf/nginx.conf /php/etc/php-fpm.conf \
        -e "s/<MEMORY_LIMIT>/$MEMORY_LIMIT/g" /php/etc/php-fpm.conf
 
+# Allow PHP-FPM processes to access environment variables without explicitly
+# naming them
+echo "clear_env = no" >> /php/etc/php-fpm.conf
+
 # Change the config file to be on the persisted data location
 ln -sf /var/lib/nextcloud/config/config.php /nextcloud/config/config.php
 


### PR DESCRIPTION
This pull request changes the main run script to ensure that the PHP FPM config sets `clear_env=no`, which prevents it from clearing all environment variables before passing the environment to child processes, therefore allowing NextCloud to see the `DB_HOST` and other environment variables we are expecting to pass to it.

Previously the PHP-FPM executor was clearing environment variables that were being passed in, preventing NextCloud from being configured correctly.

This fixes #9.