### PR TITLE
Prevent/handle version change

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,34 +2,35 @@ FROM wonderfall/nextcloud
 
 MAINTAINER Arkivum Limited
 
-# Use EnvPlate for templating
-RUN curl -sLo /usr/local/bin/ep \
-    https://github.com/kreuzwerker/envplate/releases/download/v0.0.8/ep-linux \
-    && chmod +x /usr/local/bin/ep
-
-# Use FIFOs to log from apps
-RUN mkfifo /nginx/logs/access.log && \
-    mkfifo /nginx/logs/error.log && \
-    mkfifo /php/logs/error.log
-
-# Enable APCu (see https://github.com/Wonderfall/dockerfiles/issues/197)
-RUN echo "apc.enable_cli=1" >> /php/conf.d/apcu.ini
-
 # Copy the files_mv app to NextCloud
 COPY build/files_mv /nextcloud/apps/files_mv
 
 # Copy our rootfs
 COPY rootfs /
 
-# Replace the default setup.sh with our own
-RUN mv /usr/local/bin/setup.sh /usr/local/bin/installer.sh && \
-    ln -s /usr/local/bin/arkivum-setup.sh /usr/local/bin/setup.sh
-
 # Upstream image has too many volume mounts, so use a single one and change the
 # installer to use our location instead
 VOLUME /var/lib/nextcloud
-RUN sed -i -r \
-    -e 's#(\W)/config#\1/var/lib/nextcloud/config#' \
-    -e 's#(\W)/data#\1/var/lib/nextcloud/data#' \
-    -e 's#path([^/]+)/apps2#path\1/var/lib/nextcloud/apps2#' \
-    /usr/local/bin/installer.sh
+
+# Run commands to...
+# 1) Use EnvPlate for templating
+# 2) Use FIFOs to log from apps
+# 3) Enable APCu (see https://github.com/Wonderfall/dockerfiles/issues/197)
+# 4) Allow PHP-FPM processes to access environment variables
+# 5) Replace default setup.sh with our own
+# 6) Change installer to use different volume
+RUN curl -sLo /usr/local/bin/ep \
+        https://github.com/kreuzwerker/envplate/releases/download/v0.0.8/ep-linux && \
+    chmod +x /usr/local/bin/ep && \
+    mkfifo /nginx/logs/access.log && \
+    mkfifo /nginx/logs/error.log && \
+    mkfifo /php/logs/error.log && \
+    echo "apc.enable_cli=1" >> /php/conf.d/apcu.ini && \
+    echo "clear_env=no" >> /php/etc/php-fpm.conf && \
+    mv /usr/local/bin/setup.sh /usr/local/bin/installer.sh && \
+    ln -s /usr/local/bin/arkivum-setup.sh /usr/local/bin/setup.sh && \
+    sed -i -r \
+        -e 's#(\W)/config#\1/var/lib/nextcloud/config#' \
+        -e 's#(\W)/data#\1/var/lib/nextcloud/data#' \
+        -e 's#path([^/]+)/apps2#path\1/var/lib/nextcloud/apps2#' \
+        /usr/local/bin/installer.sh

--- a/rootfs/nextcloud/config/config.php.template
+++ b/rootfs/nextcloud/config/config.php.template
@@ -41,6 +41,10 @@ $CONFIG = array (
   'version' => '12.0.3.3',
   'installed' => true,
 
+  # Update checks - we want to disable these (redeploy container to update)
+  'updatechecker' => false,
+  'has_internet_connection' => false,
+
   # Database
   'dbtype' => 'mysql',
   'dbtableprefix' => 'oc_',

--- a/rootfs/nextcloud/config/config.php.template
+++ b/rootfs/nextcloud/config/config.php.template
@@ -38,7 +38,7 @@ $CONFIG = array (
 
   # System
   'instanceid' => '${NC_INSTANCE_ID}',
-  'version' => '12.0.3.3',
+  'version' => '${NC_INSTALLED_VERSION}',
   'installed' => true,
 
   # Update checks - we want to disable these (redeploy container to update)

--- a/rootfs/usr/local/bin/arkivum-config.sh
+++ b/rootfs/usr/local/bin/arkivum-config.sh
@@ -5,6 +5,9 @@
 # auto-generated values like instance id and password salt etc.
 #
 
+# Read installed nextcloud version from our version file
+nc_version=$(cat /var/lib/nextcloud/config/version)
+
 # Capture existing values from the existing config
 # shellcheck disable=SC2016
 instance_id="$(php -r \
@@ -27,6 +30,7 @@ cp -p /nextcloud/config/config.php.template \
     /var/lib/nextcloud/config/config.php.new
 NC_DB_USER="${db_user}" \
 NC_DB_PASSWORD_CRYPTED="${db_password_crypted}" \
+NC_INSTALLED_VERSION="${nc_version}" \
 NC_INSTANCE_ID="${instance_id}" \
 NC_PASSWORD_SALT="${password_salt}" \
 NC_SECRET="${secret}" \

--- a/rootfs/usr/local/bin/arkivum-setup.sh
+++ b/rootfs/usr/local/bin/arkivum-setup.sh
@@ -63,10 +63,10 @@ cp -pr /apps2 /var/lib/nextcloud/ && \
 # STAGE 4: POST-CONFIG BOOTSTRAP ###############################################
 
 # Enable 'External Storage' plugin
-occ "app:enable files_external"
+occ app:enable files_external
 
 # Enable 'Files Move' plugin
-occ "app:enable files_mv"
+occ app:enable files_mv
 
 # Create requested external storage locations
 for storage in ${EXTERNAL_STORAGES} ; do

--- a/rootfs/usr/local/bin/run.sh
+++ b/rootfs/usr/local/bin/run.sh
@@ -19,10 +19,6 @@ sed -i -e "s/<APC_SHM_SIZE>/$APC_SHM_SIZE/g" /php/conf.d/apcu.ini \
            /nginx/conf/nginx.conf /php/etc/php-fpm.conf \
        -e "s/<MEMORY_LIMIT>/$MEMORY_LIMIT/g" /php/etc/php-fpm.conf
 
-# Allow PHP-FPM processes to access environment variables without explicitly
-# naming them
-echo "clear_env = no" >> /php/etc/php-fpm.conf
-
 # Change the config file to be on the persisted data location
 ln -sf /var/lib/nextcloud/config/config.php /nextcloud/config/config.php
 


### PR DESCRIPTION
Recently NextCloud released a new version, v12.0.4, so this pull request is all about coping with that, and hopefully future updates too.

Firstly, we actually want to disable disable NextCloud's update checker because if we want to update the version of NextCloud being deployed then we will update the image and then re-deploy the service with a new image. We don't want NextCloud or users to update the software themselves, as doing so wipes our config and resets things like external storage locations etc.

However, our upstream image, `wonderfall/nextcloud` has also been updated, which means that new builds/deploys without a cached copy of the image will use v12.0.4.3, not v12.0.3.3. This means we have to cope with the version change, even with the update checker disabled (whilst we're still using an upstream image, anwyay, see #7).

In testing, two problems were observed related to this upstream image change:

1.  Our config is hardcoded with `version = '12.0.3.3'` so NextCloud always thinks an upgrade is required, even on a new deployment
1. A change to the `occ` command means that quoted commands no longer work (which we have in our run script)

So this PR also addresses those two problems: the run script now reads the version from the `/nextcloud/version.php` file and saves it to `/var/lib/nextcloud/config/version` so we can refer to it easily. We then check the value against the value in the config file, and if it's changed then we update the config file to match. In addition, the quotes on the `occ` commands in the run script have been removed.

Lastly, this pull request includes an optimisation in the Dockerfile: the multiple `RUN` commands have been merged, reducing the number of layers in our image.

This fixes #11.