### PR TITLE
pin upstream nextcloud image to use v12.0.3

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wonderfall/nextcloud
+FROM wonderfall/nextcloud@sha256:77ddb0674be1c623457ad101a29b0a396e731d831fbd0154417b8dc7e505c225
 
 MAINTAINER Arkivum Limited
 


### PR DESCRIPTION
The upstream image, [wonderfall/nextcloud:latest](https://microbadger.com/images/wonderfall/nextcloud), has recently been updated to use [v12.0.4](https://nextcloud.com/changelog/#latest12). To avoid problems associated with this, we're pinning the image we're basing ours on until we can determine how to handle the upgrade properly.

This fixes #11.