### PR TITLE
Revert "pin upstream nextcloud image to use v12.0.3"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM wonderfall/nextcloud@sha256:77ddb0674be1c623457ad101a29b0a396e731d831fbd0154417b8dc7e505c225
+FROM wonderfall/nextcloud
 
 MAINTAINER Arkivum Limited
 


### PR DESCRIPTION
Reverts PR #13. Unfortunately the image digest it relies on is no longer available (unless you have it cached locally). We therefore need to find a different way to fix this (probably PR #12).