### PR TITLE
Improvement: handle NextCloud updates

### DIFF
--- a/rootfs/nextcloud/config/config.php.template
+++ b/rootfs/nextcloud/config/config.php.template
@@ -41,6 +41,9 @@ $CONFIG = array (
   'version' => '12.0.3.3',
   'installed' => true,
 
+  # Update checks - we want to disable these (use new Docker image to upgrade)
+  'updatechecker' => false,
+
   # Database
   'dbtype' => 'mysql',
   'dbtableprefix' => 'oc_',

--- a/rootfs/nextcloud/config/config.php.template
+++ b/rootfs/nextcloud/config/config.php.template
@@ -38,7 +38,7 @@ $CONFIG = array (
 
   # System
   'instanceid' => '${NC_INSTANCE_ID}',
-  'version' => '12.0.3.3',
+  'version' => '${NC_INSTALLED_VERSION}',
   'installed' => true,
 
   # Update checks - we want to disable these (use new Docker image to upgrade)

--- a/rootfs/usr/local/bin/arkivum-config.sh
+++ b/rootfs/usr/local/bin/arkivum-config.sh
@@ -5,6 +5,9 @@
 # auto-generated values like instance id and password salt etc.
 #
 
+# Read installed nextcloud version from our version file
+nc_version=$(cat /var/lib/nextcloud/config/version)
+
 # Capture existing values from the existing config
 # shellcheck disable=SC2016
 instance_id="$(php -r \
@@ -27,6 +30,7 @@ cp -p /nextcloud/config/config.php.template \
     /var/lib/nextcloud/config/config.php.new
 NC_DB_USER="${db_user}" \
 NC_DB_PASSWORD_CRYPTED="${db_password_crypted}" \
+NC_INSTALLED_VERSION="${nc_version}" \
 NC_INSTANCE_ID="${instance_id}" \
 NC_PASSWORD_SALT="${password_salt}" \
 NC_SECRET="${secret}" \

--- a/rootfs/usr/local/bin/arkivum-setup.sh
+++ b/rootfs/usr/local/bin/arkivum-setup.sh
@@ -62,6 +62,9 @@ cp -pr /apps2 /var/lib/nextcloud/ && \
 
 # STAGE 4: POST-CONFIG BOOTSTRAP ###############################################
 
+# Do upgrade, if required
+occ upgrade
+
 # Enable 'External Storage' plugin
 occ "app:enable files_external"
 

--- a/rootfs/usr/local/bin/arkivum-setup.sh
+++ b/rootfs/usr/local/bin/arkivum-setup.sh
@@ -66,10 +66,10 @@ cp -pr /apps2 /var/lib/nextcloud/ && \
 occ upgrade
 
 # Enable 'External Storage' plugin
-occ "app:enable files_external"
+occ app:enable files_external
 
 # Enable 'Files Move' plugin
-occ "app:enable files_mv"
+occ app:enable files_mv
 
 # Create requested external storage locations
 for storage in ${EXTERNAL_STORAGES} ; do


### PR DESCRIPTION
Issue #11 was only the tip of the iceberg. This pull request revisits #12 after further testing and experience of using NextCloud around an update event. Hopefully these changes will work for v12.0.4, and future versions too.

Firstly, the upstream `wonderfall/nextcloud:latest` image has been updated to v12.0.4, so nothing we can do can prevent this version from being installed. We therefore need to cope with this, rather than try and change or prevent it.

When the NextCloud version changes, it detects that it has changed and goes into a sort of "maintenance mode" where the only action that can be done is an upgrade. The first commit therefore runs `occ upgrade` as part of the initial set up (after the installer has run), so that we are then able to enable or disable the apps we want, etc.

Secondly, we don't really want NextCloud to apply its own updates. Because we're controlling the deployment using Docker images (or trying to), we want updates to come from a new image version, not from an ad-hoc update process. The second commit therefore disables NextCloud's update checker, so it will now no longer detect or attempt to install updates.

Updating the NextCloud version exposed the hardcoded `version` value in the config file, so this has been changed to use the value defined in the `version.php` which is part of the NextCloud distribution. We write this value to a `/var/lib/nextcloud/config/version` file, so it's easier to refer to. If the version has changed since we last ran, the config file is now re-written with the new version.

Finally, we found that it was necessary to remove some quotes from the `occ` commands in the post-config stage of the setup. These lines worked fine on v12.0.3 but not it would seem on v12.0.4.