### PR TITLE
Improvement: allow NextCloud host and scheme to be overridden in config

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,8 +48,10 @@ In addition, the following are also supported:
 | `NC_MAIL_SECURE` | What security mechanism to use when sending mail. Valid values are `ssl`, `tls` or none. | none |
 | `NC_MAIL_TIMEOUT` | The timeout to use when sending mail, in seconds. | `10` |
 | `NC_MAIL_USER` | The SMTP username to use when sending mail | none |
-| `REDIS_HOST` | The hostname of the Redis server to use for caching. |
-| `REDIS_PORT` | The port of the Redis server to use for caching. |
+| `NC_PROXY_HOSTNAME` | Overrides NextCloud's own detection of what its hostname is. Use if using a proxy and you're not getting the right URLs. | `''` |
+| `NC_PROXY_PROTOCOL` | Overrides NextCloud's own detection of what scheme it should use. Set to `https` if proxying NextCloud behind a HTTPS server. | `http` |
+| `REDIS_HOST` | The hostname of the Redis server to use for caching. | `redis` |
+| `REDIS_PORT` | The port of the Redis server to use for caching. | `6379` |
 
 External Storage
 -----------------

--- a/rootfs/nextcloud/config/config.php.template
+++ b/rootfs/nextcloud/config/config.php.template
@@ -32,6 +32,10 @@ $CONFIG = array (
   # Logging
   'loglevel' => getenv('NC_LOG_LEVEL') ?: 1,
 
+  # Proxy overwrite
+  'overwritehost' => getenv('NC_PROXY_HOSTNAME') ?: '',
+  'overwriteprotocol' => getenv('NC_PROXY_PROTOCOL') ?: 'http',
+
   #
   # Installed settings - you shouldn't need to change these, ever
   #


### PR DESCRIPTION
This pull request adds `NC_PROXY_HOSTNAME` and `NC_PROXY_PROTOCOL` environment variables to allow manual override of NextCloud's detection of what server and protocol it should use. Setting `NC_PROXY_PROTOCOL` to `https` is required if fronting NextCloud with a HTTPS proxy or load balancer.

This is currently work-in-progress because I need to do some further testing before it's ready for review.