### PR TITLE
merge RUN commands in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,34 +2,35 @@ FROM wonderfall/nextcloud
 
 MAINTAINER Arkivum Limited
 
-# Use EnvPlate for templating
-RUN curl -sLo /usr/local/bin/ep \
-    https://github.com/kreuzwerker/envplate/releases/download/v0.0.8/ep-linux \
-    && chmod +x /usr/local/bin/ep
-
-# Use FIFOs to log from apps
-RUN mkfifo /nginx/logs/access.log && \
-    mkfifo /nginx/logs/error.log && \
-    mkfifo /php/logs/error.log
-
-# Enable APCu (see https://github.com/Wonderfall/dockerfiles/issues/197)
-RUN echo "apc.enable_cli=1" >> /php/conf.d/apcu.ini
-
 # Copy the files_mv app to NextCloud
 COPY build/files_mv /nextcloud/apps/files_mv
 
 # Copy our rootfs
 COPY rootfs /
 
-# Replace the default setup.sh with our own
-RUN mv /usr/local/bin/setup.sh /usr/local/bin/installer.sh && \
-    ln -s /usr/local/bin/arkivum-setup.sh /usr/local/bin/setup.sh
-
 # Upstream image has too many volume mounts, so use a single one and change the
 # installer to use our location instead
 VOLUME /var/lib/nextcloud
-RUN sed -i -r \
-    -e 's#(\W)/config#\1/var/lib/nextcloud/config#' \
-    -e 's#(\W)/data#\1/var/lib/nextcloud/data#' \
-    -e 's#path([^/]+)/apps2#path\1/var/lib/nextcloud/apps2#' \
-    /usr/local/bin/installer.sh
+
+# Run commands to...
+# 1) Use EnvPlate for templating
+# 2) Use FIFOs to log from apps
+# 3) Enable APCu (see https://github.com/Wonderfall/dockerfiles/issues/197)
+# 4) Allow PHP-FPM processes to access environment variables
+# 5) Replace default setup.sh with our own
+# 6) Change installer to use different volume
+RUN curl -sLo /usr/local/bin/ep \
+        https://github.com/kreuzwerker/envplate/releases/download/v0.0.8/ep-linux && \
+    chmod +x /usr/local/bin/ep && \
+    mkfifo /nginx/logs/access.log && \
+    mkfifo /nginx/logs/error.log && \
+    mkfifo /php/logs/error.log && \
+    echo "apc.enable_cli=1" >> /php/conf.d/apcu.ini && \
+    echo "clear_env=no" >> /php/etc/php-fpm.conf && \
+    mv /usr/local/bin/setup.sh /usr/local/bin/installer.sh && \
+    ln -s /usr/local/bin/arkivum-setup.sh /usr/local/bin/setup.sh && \
+    sed -i -r \
+        -e 's#(\W)/config#\1/var/lib/nextcloud/config#' \
+        -e 's#(\W)/data#\1/var/lib/nextcloud/data#' \
+        -e 's#path([^/]+)/apps2#path\1/var/lib/nextcloud/apps2#' \
+        /usr/local/bin/installer.sh

--- a/rootfs/usr/local/bin/run.sh
+++ b/rootfs/usr/local/bin/run.sh
@@ -19,10 +19,6 @@ sed -i -e "s/<APC_SHM_SIZE>/$APC_SHM_SIZE/g" /php/conf.d/apcu.ini \
            /nginx/conf/nginx.conf /php/etc/php-fpm.conf \
        -e "s/<MEMORY_LIMIT>/$MEMORY_LIMIT/g" /php/etc/php-fpm.conf
 
-# Allow PHP-FPM processes to access environment variables without explicitly
-# naming them
-echo "clear_env = no" >> /php/etc/php-fpm.conf
-
 # Change the config file to be on the persisted data location
 ln -sf /var/lib/nextcloud/config/config.php /nextcloud/config/config.php
 


### PR DESCRIPTION
Previously we had several `RUN` commands in the Dockerfile, creating a layer for each. This change optimises the image, squashing these multiple layers into one.

This change also moves the change to `php-fpm.conf `from the run script to the Docker image.