### PR TITLE
check if external storages exist before creating them

### DIFF
--- a/rootfs/usr/local/bin/nextcloud-setup
+++ b/rootfs/usr/local/bin/nextcloud-setup
@@ -49,14 +49,26 @@ occ app:enable files_external
 # Enable 'Files Move' plugin
 occ app:enable files_mv
 
-# Create requested external storage locations
+# Create requested external storage locations, if they don't already exist
+storage_info="$(occ files_external:list --all --full | \
+        tail -n +4 | head -n -1 | \
+        sed -E -e 's#[|]##g' \
+               -e 's#\s\s+#|#g' \
+               -e 's#^\s##g' \
+               -e 's#,$##g' \
+               -e 's#[\][/]#/#g')"
 for storage in ${EXTERNAL_STORAGES} ; do
     storage_name="$(echo "${storage}" | cut -d: -f1)"
     storage_dir="$(echo "${storage}" | cut -d: -f2)"
-    occ files_external:create \
-        --config datadir="${storage_dir}" \
-        "${storage_name}" \
-        'local' null::null
+    if printf "%s" "${storage_info}" | grep "${storage_name}" > /dev/null ; then
+        echo "External storage '${storage_name}' already exists."
+    else
+        echo "Adding external storage '${storage_name}'..."
+        occ files_external:create \
+            --config datadir="${storage_dir}" \
+            "${storage_name}" \
+            'local' null::null
+    fi
 done
 
 # Add a wildcard record for allowed domains


### PR DESCRIPTION
This pull request addresses [RDSSARK-501](https://jiscdev.atlassian.net/browse/RDSSARK-501). We now use the `occ files_external:list` command in `nextcloud-setup` to check if a storage with the given name exists before attempting to create it.

Although the setup script is only intended to be run once, this protects against it being run multiple times inadvertently, which would result in duplicate external storages being created.