### PR TITLE
add missing user_saml app to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -73,6 +73,9 @@ COPY rootfs /
 # Copy the files_mv app to NextCloud
 COPY build/files_mv /nextcloud/apps/files_mv
 
+# Copy the user_saml app to NextCloud
+COPY build/user_saml /nextcloud/apps/user_saml
+
 VOLUME /nextcloud/themes /var/lib/nextcloud
 
 EXPOSE 8888


### PR DESCRIPTION
Somehow in cleanup and merges etc the line to copy the user_saml app to the nextcloud image got removed. This commit reinstates it, so that Shibboleth can work again.

Unfortunately this got spotted after #19 got merged, otherwise I'd have added it into that PR instead.