### PR TITLE
Improvement: add flag to control background/foreground file system scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,12 +30,11 @@ For example:
 Environment Variables
 -----------------------
 
-Most of the environment variables for this image are inherited from and [defined by `wonderfall/nextcloud`](https://github.com/Wonderfall/dockerfiles/tree/master/nextcloud#environment-variables).
-
-In addition, the following are also supported:
+The following environment variables are supported:
 
 | Variable | Description | Default Value |
 |---|---|---|
+| `SCAN_IN_FOREGROUND` | If set to `"true"`, the initial scan of configured file systems will be run as a foreground task, otherwise the scan will be performed as a background task. Running in the foreground will block and prevent NextCloud startup from completing until the scan is finished. | Undefined, causing the scan to be run in the background. |
 | `DB_PORT` | Specifies the port to use to connect to the MySQL database server. | `3306` |
 | `EXTERNAL_STORAGES` | Specifies the external storage location(s) that should be added as part of the set up. See [External Storage](#external-storage) below. | `""` |
 | `HTTP_PROTOCOL` | Overrides NextCloud's own detection of what scheme it should use. Set to `https` if proxying NextCloud behind a HTTPS server. | `http` |

--- a/rootfs/usr/local/bin/nextcloud-setup
+++ b/rootfs/usr/local/bin/nextcloud-setup
@@ -74,5 +74,12 @@ done
 # Add a wildcard record for allowed domains
 occ config:system:set trusted_domains 1 --value="*"
 
-# Rescan file system
-occ files:scan --all &
+if [ -z "${SCAN_IN_FOREGROUND}" ] ; then
+	# Rescan file system in background
+	echo "Background scan of configured file systems started."
+	occ files:scan --all &
+else
+	# Rescan file system in the foreground, blocking until it completes
+	echo "Starting foreground scan of configured file systems..."
+	occ files:scan --all
+fi


### PR DESCRIPTION
As part of our initial setup process we do a full scan of the configured file systems in NextCloud. This uses the `occ files:scan --all` command. If any of the configured file systems are large or slow, this can take a very long time to complete. Previously we've mitigated this by running the scan as a background task, but this creates its own problems, as reported [here](https://gist.github.com/fractos/4c4e7b7107b4f50866946283185818da).

This pull request lets the person doing the deployment decide what's best. We add the `BACKGROUND_SCAN` flag which, if set, will cause the scan to happen in the background, otherwise it will be run in the foreground.